### PR TITLE
Force expert annotation on 'not relevant' articles

### DIFF
--- a/src/Server/Storage/AzureStorage.fs
+++ b/src/Server/Storage/AzureStorage.fs
@@ -511,7 +511,8 @@ let saveAnnotationsToDB connectionString (annotations: ArticleAnnotations) = tas
     | Sourced | Unsourced ->
         cmd.Parameters.AddWithValue("@NumSources", annotations.Annotations.Length)  |> ignore
     | NotRelevant ->
-        cmd.Parameters.AddWithValue("@NumSources", -10)  |> ignore
+        // Assign a negative number to enforce expert annotation
+        cmd.Parameters.AddWithValue("@NumSources", 2 * ConflictCountThreshold)  |> ignore
 
     let result = cmd.ExecuteNonQuery()
     conn.Close()


### PR DESCRIPTION
When one user labels an article as 'Not relevant' and second user deems article normal and annotates it, an expert annotation is now required.